### PR TITLE
Fix sql_mode error

### DIFF
--- a/balance-mng/balance-mng-bootstrap/src/main/resources/application.properties
+++ b/balance-mng/balance-mng-bootstrap/src/main/resources/application.properties
@@ -15,7 +15,7 @@ server.port=9080
 
 # database config
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.url=jdbc:mysql://localhost:3306/balance_db
+spring.datasource.url=jdbc:mysql://localhost:3306/balance_db?sessionVariables=sql_mode=''
 spring.datasource.username=root
 spring.datasource.password=root
 

--- a/stock-mng/src/main/resources/application.properties
+++ b/stock-mng/src/main/resources/application.properties
@@ -14,7 +14,7 @@ spring.mvc.static-path-pattern=/**
 
 # database config
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.url=jdbc:mysql://localhost:3306/stock_db
+spring.datasource.url=jdbc:mysql://localhost:3306/stock_db?sessionVariables=sql_mode=''
 spring.datasource.username=root
 spring.datasource.password=root
 


### PR DESCRIPTION
When run with mysql with sql_mode=only_full_group_by there will be an error as following:

Caused by: java.sql.SQLSyntaxErrorException: Expression #2 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'stock_db.stock_tb.count' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:120) ~[mysql-connector-java-8.0.13.jar:8.0.13]
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:97) ~[mysql-connector-java-8.0.13.jar:8.0.13]
	at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:122) ~[mysql-connector-java-8.0.13.jar:8.0.13]
	at com.mysql.cj.jdbc.ClientPreparedStatement.executeInternal(ClientPreparedStatement.java:974) ~[mysql-connector-java-8.0.13.jar:8.0.13]
	at com.mysql.cj.jdbc.ClientPreparedStatement.execute(ClientPreparedStatement.java:391) ~[mysql-connector-java-8.0.13.jar:8.0.13]
	at com.zaxxer.hikari.pool.ProxyPreparedStatement.execute(ProxyPreparedStatement.java:44) ~[HikariCP-3.2.0.jar:na]
	at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.execute(HikariProxyPreparedStatement.java) ~[HikariCP-3.2.0.jar:na]
	at com.alipay.sofa.tracer.plugins.datasource.BasePreparedStatement.execute(BasePreparedStatement.java:229) ~[sofa-tracer-datasource-plugin-3.0.5.jar:3.0.5]
	... 97 common frames omitted